### PR TITLE
Feat: migrate to react-query and remove useEffect, useState

### DIFF
--- a/src/components/VideoList/index.jsx
+++ b/src/components/VideoList/index.jsx
@@ -1,39 +1,43 @@
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import axios from "axios";
 
+import CONSTANT from "../../constants/constant";
+
 function VideoList({ youtubeVideoId }) {
-  const [video, setVideo] = useState({});
+  async function fetchVideo() {
+    const response = await axios.get(
+      `${import.meta.env.VITE_BASE_URL}/videos/${youtubeVideoId}`,
+    );
 
-  useEffect(() => {
-    async function fetchVideo() {
-      const response = await axios.get(
-        `${import.meta.env.VITE_BASE_URL}/videos/${youtubeVideoId}`,
-      );
+    return response.data.video;
+  }
 
-      if (response.data.result === "ok") {
-        setVideo(response.data.video);
-      }
-    }
-
-    fetchVideo();
-  }, []);
+  const { data: video, isFetching } = useQuery({
+    queryKey: ["youtubeVideoId", youtubeVideoId],
+    queryFn: () => fetchVideo(),
+    staleTime: CONSTANT.FIVE_MINUTE_IN_MILLISECONDS,
+  });
 
   return (
-    <Link to={`/watch?${video.youtubeVideoId}`} state={{ video }}>
-      <div className="flex w-screen mb-2">
-        <img
-          className="w-[300px] mr-2"
-          src={video.thumbnailURL}
-          alt="thumbnail"
-        />
-        <div>
-          <h1>{video.title}</h1>
-          <p>{video.channel}</p>
-          <p>{video.description}</p>
-        </div>
-      </div>
-    </Link>
+    <div>
+      {!isFetching && (
+        <Link to={`/watch?${video.youtubeVideoId}`} state={{ video }}>
+          <div className="flex w-screen mb-2">
+            <img
+              className="w-[300px] mr-2"
+              src={video.thumbnailURL}
+              alt="thumbnail"
+            />
+            <div>
+              <h1>{video.title}</h1>
+              <p>{video.channel}</p>
+              <p>{video.description}</p>
+            </div>
+          </div>
+        </Link>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
### [[FE] 단일 비디오 fetching 개선](https://www.notion.so/seongjunhong/Kanban-Task-b371ec4af16c4fe59929d5d57d302add?p=6f6fb1da37d24cd080033f5f357a94d4&pm=s)

### description

- useState 와 useEffect로 데이터를 가져와 상태관리를 하던 것을 react-query로 migration 했습니다.
- video 데이터를 fetching 중일 때 썸네일 이미지가 로딩되는 순간이 보이는 현상을 보이지 않게 했습니다
- fetching 중일 때 클릭 시 디테일 페이지의 내용이 보이지 않는 현상을 수정했습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.

### 화면캡쳐 (필요시)

#### Before
![스크린샷 2024-02-07 오전 2 53 21](https://github.com/Team-Office360/NeedleInHaystack-client/assets/102589090/e4af49c9-d3a1-4e38-8900-f7dfc82560dc)

#### After
<img width="615" alt="스크린샷 2024-02-07 오전 2 55 02" src="https://github.com/Team-Office360/NeedleInHaystack-client/assets/102589090/69e3aef7-b814-4930-bd87-af520b4a1f37">
