### PR TITLE
Feat: check spelling of userInput

### DIFF
--- a/src/apis/useFetchAllVideos.jsx
+++ b/src/apis/useFetchAllVideos.jsx
@@ -3,13 +3,13 @@ import axios from "axios";
 
 import CONSTANT from "../constants/constant";
 
-function useFetchAllVideos(query) {
+function useFetchAllVideos(query, shouldCheckSpell = true) {
   async function fetchAllVideos({ pageParam }) {
     const response = await axios.post(
       `${import.meta.env.VITE_BASE_URL}/keywords/`,
       {
         userInput: query.split("+"),
-        shouldSpellCheck: true,
+        shouldCheckSpell,
         pageParam,
       },
     );
@@ -18,7 +18,7 @@ function useFetchAllVideos(query) {
   }
 
   return useInfiniteQuery({
-    queryKey: ["search", query],
+    queryKey: ["search", query, shouldCheckSpell],
     queryFn: fetchAllVideos,
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.nextPage,

--- a/src/components/ResultPage/index.jsx
+++ b/src/components/ResultPage/index.jsx
@@ -1,4 +1,3 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
 import { useInView } from "react-intersection-observer";
@@ -9,20 +8,32 @@ import VideoList from "../VideoList";
 import { Loading, LoadingSpin } from "../shared/Loading";
 
 import useFetchAllVideos from "../../apis/useFetchAllVideos";
+import { useCheckSpellStore } from "../../store/store";
 
 function ResultPage() {
   const location = useLocation();
+  const { shouldCheckSpell, setShouldCheckSpell } = useCheckSpellStore();
   const query = location.search.split("?search_query=")[1];
   const { ref, inView } = useInView();
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
-    useFetchAllVideos(query);
+    shouldCheckSpell
+      ? useFetchAllVideos(query)
+      : useFetchAllVideos(query, false);
 
   useEffect(() => {
     if (inView && hasNextPage) {
       fetchNextPage();
     }
   }, [inView, hasNextPage, fetchNextPage]);
+
+  function handleSearchInsteadClick() {
+    if (shouldCheckSpell) {
+      setShouldCheckSpell(false);
+    } else {
+      setShouldCheckSpell(true);
+    }
+  }
 
   return (
     <div className="flex flex-col items-center mt-10">
@@ -39,6 +50,23 @@ function ResultPage() {
       )}
       {status === "success" && data.pages[0].result !== "null" ? (
         <>
+          {data.pages[0].query !== data.pages[0].correctedInput && (
+            <p className="mt-3 mb-3">
+              Showing results for
+              <span className="font-bold italic ml-2 mr-2" role="button">
+                {data.pages[0].correctedInput}
+              </span>
+              Search instead for
+              <span
+                className="font-bold ml-2 hover:text-purple-900 hover:underline"
+                onClick={handleSearchInsteadClick}
+                role="button"
+                tabIndex={0}
+              >
+                {data.pages[0].query}
+              </span>
+            </p>
+          )}
           {data.pages.map((group) =>
             group.videos.map((video) => {
               const youtubeVideoId = video[0];
@@ -57,9 +85,28 @@ function ResultPage() {
           </div>
         </>
       ) : (
-        <div className="mt-10 text-center font-bold">
-          <div className="text-xl">No results found</div>
-          <p className="mt-4">
+        <div className="mt-3 text-center">
+          {!shouldCheckSpell && (
+            <p className="mb-10 text-4xl">
+              Did you mean
+              <span
+                className="font-bold italic ml-2 hover:text-purple-900 hover:underline"
+                onClick={handleSearchInsteadClick}
+                role="button"
+                tabIndex={0}
+              >
+                {data?.pages[0].recommendedSearchKeyword}
+              </span>
+              ?
+            </p>
+          )}
+          <p className="mb-10">
+            Your search -
+            <span className="font-bold ml-2 mr-2">{data?.pages[0].query}</span>
+            did not match any documents.
+          </p>
+          <div className="text-xl font-bold">No results found</div>
+          <p className="font-bold mt-5">
             Try different keywords or remove search filters
           </p>
         </div>

--- a/src/components/SearchInput/index.jsx
+++ b/src/components/SearchInput/index.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
-import useUserInputStore from "../../store/store";
+
+import { useUserInputStore, useCheckSpellStore } from "../../store/store";
 
 function SearchInput() {
   const { userInput, setUserInput } = useUserInputStore();
+  const { shouldCheckSpell, setShouldCheckSpell } = useCheckSpellStore();
   const [autoCompletions, setAutoCompletions] = useState([]);
   const [selectedItemIndex, setSelectedItemIndex] = useState(-1);
   const [showAutoCompletions, setShowAutoCompletions] = useState(false);
@@ -23,7 +25,7 @@ function SearchInput() {
         );
         const { data } = response;
 
-        setAutoCompletions(data);
+        setAutoCompletions(data.searchHistories);
       } catch (error) {
         console.log(error);
       }
@@ -48,6 +50,10 @@ function SearchInput() {
     const pressedKey = event.key;
 
     if (pressedKey === "ArrowDown" || pressedKey === "ArrowUp") {
+      if (autoCompletions.length === 0) {
+        return;
+      }
+
       arrowKeyPressed.current = true;
       event.preventDefault();
       if (!showAutoCompletions) {
@@ -87,6 +93,10 @@ function SearchInput() {
       setShowAutoCompletions(false);
       setSelectedItemIndex(-1);
 
+      if (!shouldCheckSpell) {
+        setShouldCheckSpell(true);
+      }
+
       navigate(`/results?search_query=${keywords}`);
     }
   }
@@ -120,6 +130,7 @@ function SearchInput() {
           value={userInput}
           onChange={handleUserInputChange}
           onKeyDown={handleKeyPress}
+          spellCheck="false"
           autoFocus
         />
         {autoCompletions.length > 0 && showAutoCompletions && (

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -5,4 +5,9 @@ const useUserInputStore = create((set) => ({
   setUserInput: (userInput) => set({ userInput }),
 }));
 
-export default useUserInputStore;
+const useCheckSpellStore = create((set) => ({
+  shouldCheckSpell: true,
+  setShouldCheckSpell: (shouldCheckSpell) => set({ shouldCheckSpell }),
+}));
+
+export { useUserInputStore, useCheckSpellStore };


### PR DESCRIPTION
### [[FE] 자동 교정된 스팰링으로 대신 검색](https://www.notion.so/seongjunhong/FE-0a341693dccf486baa30510210fdaf45?pvs=4)

### 작업한 내용
검색어 스팰링 체크 기능 관련하여 아래 케이스들을 핸들링하는 로직을 짜보았습니다.

**Case 1. 올바른 스팰링 후보가 있을 경우**
: 자동 수정한 검색어로 대신 검색
: 유저가 처음 입력한 검색어로도 검색이 가능하게끔 옵션을 제공
: 처음 입력한 검색어로 다시 검색하기를 원할시, 
1. 영상 리스트가 있으면 영상 리스트 렌더
2. 영상 리스트가 없으면 `Did you mean apple?` 렌더 (그리고 클릭하면 해당 추천 검색어로 재검색)

<br>

**Case 2: 올바른 스팰링 후보가 없을 경우**
: `No results found` 렌더

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.

### 화면캡쳐 (필요시)

https://github.com/Team-Office360/NeedleInHaystack-client/assets/139360841/6f25f72d-82ec-4464-a552-1118759375d8

