### PR TITLE
Feat: video in videoList plays on hover event

### DIFF
--- a/src/components/Video/index.jsx
+++ b/src/components/Video/index.jsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import ReactPlayer from "react-player/youtube";
 
+import CONSTANT from "../../constants/constant";
+
 function Video({ video }) {
-  const youtubeURL = `https://www.youtube.com/watch?v=${video.youtubeVideoId}`;
   const [isAvailable, setIsAvailable] = useState(true);
 
   return (
@@ -18,7 +19,7 @@ function Video({ video }) {
             }}
             width={800}
             height={450}
-            url={youtubeURL}
+            url={CONSTANT.YOUTUBE_URL + video.youtubeVideoId}
             onError={() => {
               setIsAvailable(false);
             }}

--- a/src/components/VideoList/index.jsx
+++ b/src/components/VideoList/index.jsx
@@ -4,11 +4,24 @@ import ReactPlayer from "react-player/youtube";
 
 import useFetchSingleVideo from "../../apis/useFetchSingleVideo";
 
+import CONSTANT from "../../constants/constant";
+
 function VideoList({ youtubeVideoId }) {
   const [isHover, setIsHover] = useState(false);
   const [isAvailable, setIsAvailable] = useState(true);
   const { data: video, isFetching } = useFetchSingleVideo(youtubeVideoId);
-  const youtubeURL = `https://www.youtube.com/watch?v=${youtubeVideoId}`;
+
+  function handleMouseEnter(event) {
+    setTimeout(() => {
+      setIsHover(true);
+    }, 300);
+    event.stopPropagation();
+  }
+
+  function handleMouseLeave(event) {
+    setIsHover(false);
+    event.stopPropagation();
+  }
 
   return (
     <div>
@@ -18,16 +31,8 @@ function VideoList({ youtubeVideoId }) {
             <div className="flex min-w-0 gap-x-4">
               {isAvailable ? (
                 <div
-                  onMouseEnter={(event) => {
-                    setTimeout(() => {
-                      setIsHover(true);
-                    }, 300);
-                    event.stopPropagation();
-                  }}
-                  onMouseLeave={(event) => {
-                    setIsHover(false);
-                    event.stopPropagation();
-                  }}
+                  onMouseEnter={handleMouseEnter}
+                  onMouseLeave={handleMouseLeave}
                 >
                   <ReactPlayer
                     style={{
@@ -37,7 +42,7 @@ function VideoList({ youtubeVideoId }) {
                     }}
                     width={355}
                     height={200}
-                    url={youtubeURL}
+                    url={CONSTANT.YOUTUBE_URL + youtubeVideoId}
                     playing={isHover}
                     onError={() => {
                       setIsAvailable(false);

--- a/src/components/VideoList/index.jsx
+++ b/src/components/VideoList/index.jsx
@@ -1,10 +1,14 @@
-import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import ReactPlayer from "react-player/youtube";
 
 import useFetchSingleVideo from "../../apis/useFetchSingleVideo";
 
 function VideoList({ youtubeVideoId }) {
+  const [isHover, setIsHover] = useState(false);
+  const [isAvailable, setIsAvailable] = useState(true);
   const { data: video, isFetching } = useFetchSingleVideo(youtubeVideoId);
+  const youtubeURL = `https://www.youtube.com/watch?v=${youtubeVideoId}`;
 
   return (
     <div>
@@ -12,11 +16,42 @@ function VideoList({ youtubeVideoId }) {
         <Link to={`/watch?${video.youtubeVideoId}`} state={{ video }}>
           <div className="flex justify-between w-screen gap-x-6 p-2">
             <div className="flex min-w-0 gap-x-4">
-              <img
-                className="h-[200px] flex-none rounded-md bg-gray-50"
-                src={video.thumbnailURL}
-                alt="thumbnail"
-              />
+              {isAvailable ? (
+                <div
+                  onMouseEnter={(event) => {
+                    setTimeout(() => {
+                      setIsHover(true);
+                    }, 300);
+                    event.stopPropagation();
+                  }}
+                  onMouseLeave={(event) => {
+                    setIsHover(false);
+                    event.stopPropagation();
+                  }}
+                >
+                  <ReactPlayer
+                    style={{
+                      flex: "none",
+                      borderColor: "rgb(100 116 139)",
+                      backgroundColor: "rgb(249 250 251)",
+                    }}
+                    width={355}
+                    height={200}
+                    url={youtubeURL}
+                    playing={isHover}
+                    onError={() => {
+                      setIsAvailable(false);
+                    }}
+                  />
+                </div>
+              ) : (
+                <img
+                  className="h-[200px] flex-none rounded-md bg-gray-50"
+                  src={video.thumbnailURL}
+                  alt="thumbnail"
+                />
+              )}
+
               <div className="min-w-0 flex-auto">
                 <p className="text-lg font-semibold leading-6 text-gray-900">
                   {video.title}

--- a/src/constants/constant.js
+++ b/src/constants/constant.js
@@ -1,6 +1,7 @@
 const CONSTANT = {
   SCROLL_WAIT_TIME: 300,
   FIVE_MINUTE_IN_MILLISECONDS: 5 * 60 * 1000,
+  YOUTUBE_URL: "https://www.youtube.com/watch?v=",
 };
 
 export default CONSTANT;


### PR DESCRIPTION
### [[FE] 썸네일 동영상 호버 시 영상 재생 기능](https://www.notion.so/seongjunhong/Kanban-Task-b371ec4af16c4fe59929d5d57d302add?p=e8adf0d06a67493cbee32ed90420dd53&pm=s)

### description

- 비디오 리스트에서 비디오 썸네일에 마우스를 호버 시 영상이 재생됩니다.
- 호버 이벤트 종료 시 영상이 일시정지 합니다.
- 삭제, 비공개, 외부 임베딩 불가 영상에 대해산 썸네일 이미지로 대체 합니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.

### 화면캡쳐 (필요시)

https://github.com/Team-Office360/NeedleInHaystack-client/assets/102589090/5128921c-0a34-4f74-821a-28f2c14ff35d



### etc

- 추후에 react-player 보다 더 가벼운 플레이어로 migration 할 가능성 있습니다.
