### PR TITLE
Feat: result page searchtime

### DIFF
--- a/src/apis/useFetchAllVideos.jsx
+++ b/src/apis/useFetchAllVideos.jsx
@@ -15,8 +15,10 @@ function useFetchAllVideos(query, shouldCheckSpell = true) {
       },
     );
     const fetchEndTime = Date.now();
-    response.data.requestTime =
+    const requestTime =
       Math.floor(((fetchEndTime - fetchStartTime) / 1000) * 100) / 100;
+
+    response.data.requestTime = requestTime;
 
     return response.data;
   }

--- a/src/apis/useFetchAllVideos.jsx
+++ b/src/apis/useFetchAllVideos.jsx
@@ -15,10 +15,10 @@ function useFetchAllVideos(query, shouldCheckSpell = true) {
       },
     );
     const fetchEndTime = Date.now();
-    const requestTime =
+    const videosFetchTime =
       Math.floor(((fetchEndTime - fetchStartTime) / 1000) * 100) / 100;
 
-    response.data.requestTime = requestTime;
+    response.data.videosFetchTime = videosFetchTime;
 
     return response.data;
   }

--- a/src/apis/useFetchAllVideos.jsx
+++ b/src/apis/useFetchAllVideos.jsx
@@ -5,6 +5,7 @@ import CONSTANT from "../constants/constant";
 
 function useFetchAllVideos(query, shouldCheckSpell = true) {
   async function fetchAllVideos({ pageParam }) {
+    const fetchStartTime = Date.now();
     const response = await axios.post(
       `${import.meta.env.VITE_BASE_URL}/keywords/`,
       {
@@ -13,6 +14,9 @@ function useFetchAllVideos(query, shouldCheckSpell = true) {
         pageParam,
       },
     );
+    const fetchEndTime = Date.now();
+    response.data.requestTime =
+      Math.floor(((fetchEndTime - fetchStartTime) / 1000) * 100) / 100;
 
     return response.data;
   }

--- a/src/components/ResultPage/index.jsx
+++ b/src/components/ResultPage/index.jsx
@@ -68,12 +68,10 @@ function ResultPage() {
                 </span>
               </p>
             )}
-            {data.pages[0].totalVideosCount && (
-              <div className="flex-none ml-2 mr-auto font-black text-sm">
-                About {data.pages[0].totalVideosCount} results (
-                {data.pages[0].requestTime} seconds)
-              </div>
-            )}
+            <div className="ml-2 mr-auto font-medium text-sm text-gray-500">
+              About {data.pages[0].totalVideosCount} results (
+              {data.pages[0].requestTime} seconds)
+            </div>
             {data.pages.map((group) =>
               group.videos.map((video, index) => {
                 const youtubeVideoId = video[0];
@@ -98,33 +96,38 @@ function ResultPage() {
             <div>{!hasNextPage ? "Nothing more to load" : "more..."}</div>
           </>
         ) : (
-          <div className="mt-3 text-center">
-            {!shouldCheckSpell && (
-              <p className="mb-10 text-4xl">
-                Did you mean
-                <span
-                  className="font-bold italic ml-2 hover:text-purple-900 hover:underline"
-                  onClick={handleSearchInsteadClick}
-                  role="button"
-                  tabIndex={0}
-                >
-                  {data?.pages[0].recommendedSearchKeyword}
+          <>
+            <div className="ml-2 mr-auto font-medium text-sm text-gray-500">
+              About 0 results ({data.pages[0].requestTime} seconds)
+            </div>
+            <div className="mt-3 text-center">
+              {!shouldCheckSpell && (
+                <p className="mb-10 text-4xl">
+                  Did you mean
+                  <span
+                    className="font-bold italic ml-2 hover:text-purple-900 hover:underline"
+                    onClick={handleSearchInsteadClick}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    {data?.pages[0].recommendedSearchKeyword}
+                  </span>
+                  ?
+                </p>
+              )}
+              <p className="mb-10">
+                Your search -
+                <span className="font-bold ml-2 mr-2">
+                  {data?.pages[0].query}
                 </span>
-                ?
+                did not match any documents.
               </p>
-            )}
-            <p className="mb-10">
-              Your search -
-              <span className="font-bold ml-2 mr-2">
-                {data?.pages[0].query}
-              </span>
-              did not match any documents.
-            </p>
-            <div className="text-xl font-bold">No results found</div>
-            <p className="font-bold mt-5">
-              Try different keywords or remove search filters
-            </p>
-          </div>
+              <div className="text-xl font-bold">No results found</div>
+              <p className="font-bold mt-5">
+                Try different keywords or remove search filters
+              </p>
+            </div>
+          </>
         ))}
     </div>
   );

--- a/src/components/ResultPage/index.jsx
+++ b/src/components/ResultPage/index.jsx
@@ -70,7 +70,7 @@ function ResultPage() {
             )}
             <div className="ml-2 mr-auto font-medium text-sm text-gray-500">
               About {data.pages[0].totalVideosCount} results (
-              {data.pages[0].requestTime} seconds)
+              {data.pages[0].videosFetchTime} seconds)
             </div>
             {data.pages.map((group) =>
               group.videos.map((video, index) => {
@@ -98,7 +98,7 @@ function ResultPage() {
         ) : (
           <>
             <div className="ml-2 mr-auto font-medium text-sm text-gray-500">
-              About 0 results ({data.pages[0].requestTime} seconds)
+              About 0 results ({data.pages[0].videosFetchTime} seconds)
             </div>
             <div className="mt-3 text-center">
               {!shouldCheckSpell && (

--- a/src/components/ResultPage/index.jsx
+++ b/src/components/ResultPage/index.jsx
@@ -68,6 +68,12 @@ function ResultPage() {
                 </span>
               </p>
             )}
+            {data.pages[0].totalVideosCount && (
+              <div className="flex-none ml-2 mr-auto font-black text-sm">
+                About {data.pages[0].totalVideosCount} results (
+                {data.pages[0].requestTime} seconds)
+              </div>
+            )}
             {data.pages.map((group) =>
               group.videos.map((video, index) => {
                 const youtubeVideoId = video[0];


### PR DESCRIPTION
### [[FE/BE] 검색 성능 측정 및 표기](https://www.notion.so/seongjunhong/Kanban-Task-b371ec4af16c4fe59929d5d57d302add?p=e425eb46be49497181eeac4306c8f950&pm=s)

### description

- useFetchAllVideos 에 응답 시간 측정 로직을 추가했습니다
- ResultPage에서 응답이 있을 시 결과의 갯수와 시간을 보여줍니다
- 무한스크롤과 상관 없이 사용자 인풋 기반으로 가능한 모든 결과의 갯수를 보여줍니다

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.

### 화면캡쳐 (필요시)

https://github.com/Team-Office360/NeedleInHaystack-client/assets/102589090/049e3a35-695b-4195-9d3b-d3e16068b86b