### PR TITLE
Feat: make VideoDetailPage responsive and add closing/selecting transcript language option

### DIFF
--- a/src/components/Video/index.jsx
+++ b/src/components/Video/index.jsx
@@ -23,6 +23,7 @@ function Video({ video, playerRef, setCurrentVideoTime }) {
     }
 
     handleResize();
+
     window.addEventListener("resize", handleResize);
 
     return () => window.removeEventListener("resize", handleResize);

--- a/src/components/Video/index.jsx
+++ b/src/components/Video/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import ReactPlayer from "react-player/youtube";
 import CONSTANT from "../../constants/constant";
 import { usePlayerDimensions } from "../../store/store";
@@ -8,12 +8,12 @@ function Video({ video, playerRef, setCurrentVideoTime }) {
   const [showMore, setShowMore] = useState(false);
   const { playerDimensions, setPlayerDimensions } = usePlayerDimensions();
 
+  const playerContainerRef = useRef();
+
   useEffect(() => {
     function handleResize() {
-      const playerContainer = document.getElementById("player-container");
-
-      if (playerContainer) {
-        const rect = playerContainer.getBoundingClientRect();
+      if (playerContainerRef) {
+        const rect = playerContainerRef.current.getBoundingClientRect();
 
         setPlayerDimensions({
           width: `${rect.width}px`,
@@ -33,7 +33,11 @@ function Video({ video, playerRef, setCurrentVideoTime }) {
   }
 
   return (
-    <div id="player-container" className="relative w-full">
+    <div
+      id="player-container"
+      ref={playerContainerRef}
+      className="relative w-full"
+    >
       {isAvailable ? (
         <div className="absolute mt-4 ml-4 mb-4">
           <ReactPlayer
@@ -51,7 +55,7 @@ function Video({ video, playerRef, setCurrentVideoTime }) {
             width={playerDimensions.width}
             height={playerDimensions.height}
           />
-          <div className="mt-4 mb-4 p-2 border-gray-500 rounded-xl bg-gray-100">
+          <div className="my-4 p-2 border-gray-500 rounded-xl bg-gray-100">
             <div className="mb-3 font-bold text-xl">{video.title}</div>
             <div className="mb-3 font-bold">{video.channel}</div>
             {video.description.length <= 100 ? (

--- a/src/components/Video/index.jsx
+++ b/src/components/Video/index.jsx
@@ -1,25 +1,44 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import ReactPlayer from "react-player/youtube";
-
 import CONSTANT from "../../constants/constant";
+import { usePlayerDimensions } from "../../store/store";
 
 function Video({ video, playerRef, setCurrentVideoTime }) {
   const [isAvailable, setIsAvailable] = useState(true);
+  const [showMore, setShowMore] = useState(false);
+  const { playerDimensions, setPlayerDimensions } = usePlayerDimensions();
+
+  useEffect(() => {
+    function handleResize() {
+      const playerContainer = document.getElementById("player-container");
+
+      if (playerContainer) {
+        const rect = playerContainer.getBoundingClientRect();
+
+        setPlayerDimensions({
+          width: `${rect.width}px`,
+          height: `${(rect.width * 9) / 16}px`,
+        });
+      }
+    }
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  function handleMoreClick() {
+    setShowMore((prev) => !prev);
+  }
 
   return (
-    <div>
+    <div id="player-container" className="relative w-full">
       {isAvailable ? (
-        <>
+        <div className="absolute mt-4 ml-4 mb-4">
           <ReactPlayer
+            className="overflow-hidden rounded-xl"
             ref={playerRef}
-            style={{
-              marginTop: 80,
-              marginLeft: 16,
-              borderWidth: 2,
-              borderColor: "rgb(100 116 139)",
-            }}
-            width={800}
-            height={450}
             url={CONSTANT.YOUTUBE_URL + video.youtubeVideoId}
             onError={() => {
               setIsAvailable(false);
@@ -29,25 +48,40 @@ function Video({ video, playerRef, setCurrentVideoTime }) {
             onProgress={(progress) =>
               setCurrentVideoTime(parseInt(progress.playedSeconds, 10))
             }
+            width={playerDimensions.width}
+            height={playerDimensions.height}
           />
-          <div className="flex flex-col w-[800px] mt-2 ml-4 mb-4 p-2 border-2 border-slate-500">
-            <div className="border font-bold">제목: {video.title}</div>
-            <div className="border">설명: {video.description}</div>
-            <div className="border">채널명: {video.channel}</div>
-            {video.tag === " " || (
-              <div className="border">태그: {video.tag}</div>
+          <div className="mt-4 mb-4 p-2 border-gray-500 rounded-xl bg-gray-100">
+            <div className="mb-3 font-bold text-xl">{video.title}</div>
+            <div className="mb-3 font-bold">{video.channel}</div>
+            {video.description.length <= 100 ? (
+              <div>{video.description}</div>
+            ) : (
+              <button className="text-left" onClick={handleMoreClick}>
+                {showMore ? (
+                  <>
+                    {video.description}
+                    <span className="font-bold">Show less</span>
+                  </>
+                ) : (
+                  <>
+                    {video.description.slice(0, 100)}
+                    <span className="ml-2 font-bold">... more</span>
+                  </>
+                )}
+              </button>
             )}
           </div>
-        </>
+        </div>
       ) : (
         <>
           <img
-            className="w-[800px] h-[450px] mt-20 ml-4 border-2 border-slate-500"
+            className="w-full max-w-xl h-48 mt-20 ml-4 border-2 border-gray-500"
             src={video.thumbnailURL}
             alt="thumbnail"
           />
-          <div className="flex flex-col w-[800px] mt-2 ml-4 mb-4 p-2 border-2 border-slate-500">
-            <div className="border font-bold text-red-500 uppercase ">
+          <div className="max-w-xl mt-2 ml-4 mb-4 p-2 border-2 border-gray-500">
+            <div className="border font-bold text-red-500 uppercase">
               This video is no longer available and archived by Haystack
             </div>
             <div className="border font-bold">제목: {video.title}</div>

--- a/src/components/VideoDetailPage/index.jsx
+++ b/src/components/VideoDetailPage/index.jsx
@@ -26,19 +26,21 @@ function VideoDetailPage() {
   return (
     <>
       <Header />
-      <Video
-        video={video}
-        playerRef={playerRef}
-        setCurrentVideoTime={setCurrentVideoTime}
-      />
-      <VideoScript
-        currentVideoTime={currentVideoTime}
-        seekToTime={handleSeekToTime}
-        youtubeVideoId={video.youtubeVideoId}
-        transcript={video.transcript}
-        transcripts={video.transcripts}
-        transcriptTimeLines={video.transcriptTimeLines}
-      />
+      <div className="flex">
+        <Video
+          video={video}
+          playerRef={playerRef}
+          setCurrentVideoTime={setCurrentVideoTime}
+        />
+        <VideoScript
+          currentVideoTime={currentVideoTime}
+          seekToTime={handleSeekToTime}
+          youtubeVideoId={video.youtubeVideoId}
+          transcript={video.transcript}
+          transcripts={video.transcripts}
+          transcriptTimeLines={video.transcriptTimeLines}
+        />
+      </div>
     </>
   );
 }

--- a/src/components/VideoScript/index.jsx
+++ b/src/components/VideoScript/index.jsx
@@ -47,6 +47,7 @@ function VideoScript({
       const isInTime =
         timeToSeconds(transcriptTimeLine) <= currentVideoTime &&
         timeToSeconds(transcriptTimeLines[index + 1]) > currentVideoTime;
+
       if (isInTime) {
         setFocusedIndex(index);
       }

--- a/src/components/VideoScript/index.jsx
+++ b/src/components/VideoScript/index.jsx
@@ -82,7 +82,7 @@ function VideoScript({
       className="overflow-y-auto w-[35rem] mr-4 mt-5 ml-10 border-2 border-grey-800 rounded-xl"
       style={{ height: showTranscript ? playerDimensions.height : "" }}
     >
-      <div className="flex items-center justify-between sticky z-10 p-2 top-0  bg-white font-bold text-2xl">
+      <div className="flex items-center justify-between sticky z-10 p-2 top-0 bg-white font-bold text-2xl">
         Transcript
         <div className="relative">
           <button
@@ -112,7 +112,6 @@ function VideoScript({
           </button>
         </div>
       </div>
-
       {showTranscript && (
         <div className="overflow-y-auto overflow-x-hidden">
           {transcript !== " " &&

--- a/src/components/VideoScript/index.jsx
+++ b/src/components/VideoScript/index.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import translate from "translate";
 
 import timeToSeconds from "../../utils/timeToSeconds";
+import { usePlayerDimensions } from "../../store/store";
 
 function VideoScript({
   currentVideoTime,
@@ -13,6 +14,10 @@ function VideoScript({
 }) {
   const [koreanScripts, setKoreanScripts] = useState([]);
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const [showTranscript, setShowTranscript] = useState(true);
+  const [transcriptLanguage, setTranscriptLanguage] = useState("EN");
+  const [showLanguageDropdown, setShowLanguageDropdown] = useState(false);
+  const { playerDimensions } = usePlayerDimensions();
   const scriptRef = useRef([]);
 
   useEffect(() => {
@@ -47,38 +52,100 @@ function VideoScript({
       }
     });
 
-    scriptRef.current[focusedIndex].scrollIntoView({
-      behavior: "smooth",
-      block: "start",
-      inline: "start",
-    });
-  }, [currentVideoTime]);
+    if (showTranscript) {
+      scriptRef.current[focusedIndex].scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+        inline: "start",
+      });
+    }
+  }, [currentVideoTime, showTranscript]);
+
+  function handleShowTranscriptButton() {
+    setShowTranscript((prev) => !prev);
+    setShowLanguageDropdown(false);
+  }
+
+  function handleTranscriptLanguageButton() {
+    if (showTranscript) {
+      setShowLanguageDropdown((prev) => !prev);
+    }
+  }
+
+  function handleLanguageSelect(language) {
+    setTranscriptLanguage(language);
+    setShowLanguageDropdown(false);
+  }
 
   return (
-    <div className="absolute top-[176px] left-[830px] h-[610px] mr-4 p-2 border-2 border-slate-500 text-justify overflow-scroll">
-      {transcript !== " " &&
-        transcriptTimeLines.map((transcriptTimeLine, index) => {
-          const isInTime =
-            timeToSeconds(transcriptTimeLine) <= currentVideoTime &&
-            timeToSeconds(transcriptTimeLines[index + 1]) > currentVideoTime;
+    <div
+      className="overflow-y-auto w-[35rem] mr-4 mt-5 ml-10 border-2 border-grey-800 rounded-xl"
+      style={{ height: showTranscript ? playerDimensions.height : "" }}
+    >
+      <div className="flex items-center justify-between sticky z-10 p-2 top-0  bg-white font-bold text-2xl">
+        Transcript
+        <div className="relative">
+          <button
+            className="mr-4 text-sm"
+            onClick={handleTranscriptLanguageButton}
+          >
+            {transcriptLanguage}
+          </button>
+          {showLanguageDropdown && (
+            <div className="absolute w-20 mt-1 py-1 top-full right-0 bg-white border border-gray-300 ">
+              <button
+                className="block w-full text-left px-4 py-2 text-sm hover:bg-gray-100"
+                onClick={() => handleLanguageSelect("EN")}
+              >
+                EN
+              </button>
+              <button
+                className="block w-full text-left px-4 py-2 text-sm hover:bg-gray-100"
+                onClick={() => handleLanguageSelect("KR")}
+              >
+                KR
+              </button>
+            </div>
+          )}
+          <button onClick={handleShowTranscriptButton}>
+            {showTranscript ? "-" : "+"}
+          </button>
+        </div>
+      </div>
 
-          return (
-            <button
-              key={youtubeVideoId + transcriptTimeLine + transcripts[index]}
-              className={`${isInTime && "bg-red-100"} flex hover:bg-gray-100`}
-              onClick={() => {
-                seekToTime(timeToSeconds(transcriptTimeLine));
-              }}
-              ref={(element) => {
-                scriptRef.current[index] = element;
-              }}
-            >
-              <p className="w-12 mr-2">{transcriptTimeLine}</p>
-              <p className="w-48">{transcripts[index]}</p>
-              <p className="w-48">{koreanScripts[index]}</p>
-            </button>
-          );
-        })}
+      {showTranscript && (
+        <div className="overflow-y-auto overflow-x-hidden">
+          {transcript !== " " &&
+            transcriptTimeLines.map((transcriptTimeLine, index) => {
+              const isInTime =
+                timeToSeconds(transcriptTimeLine) <= currentVideoTime &&
+                timeToSeconds(transcriptTimeLines[index + 1]) >
+                  currentVideoTime;
+
+              return (
+                <button
+                  key={youtubeVideoId + transcriptTimeLine + transcripts[index]}
+                  className={`flex w-full ${isInTime && "bg-red-100"} hover:bg-red-50`}
+                  onClick={() => {
+                    seekToTime(timeToSeconds(transcriptTimeLine));
+                  }}
+                  ref={(element) => {
+                    scriptRef.current[index] = element;
+                  }}
+                >
+                  <p className="w-12 m-2 px-1 rounded bg-blue-200 text-sky-600 font-bold">
+                    {transcriptTimeLine}
+                  </p>
+                  <p className="m-2 text-left">
+                    {transcriptLanguage === "EN"
+                      ? transcripts[index]
+                      : koreanScripts[index]}
+                  </p>
+                </button>
+              );
+            })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -25,9 +25,15 @@ const useHeaderStateStore = create((set) => ({
   setHeaderState: (headerState) => set({ headerState }),
 }));
 
+const usePlayerDimensions = create((set) => ({
+  playerDimensions: { width: "100%", height: "100%" },
+  setPlayerDimensions: (playerDimensions) => set({ playerDimensions }),
+}));
+
 export {
   useUserInputStore,
   useCheckSpellStore,
   useUserStore,
   useHeaderStateStore,
+  usePlayerDimensions,
 };


### PR DESCRIPTION
### [[FE] 동영상 디테일 페이지 - 반응형 페이지](https://www.notion.so/seongjunhong/FE-a1021735d57644b481eba6e74191db9a?pvs=4)

### 작업한 내용
1. 유저가 윈도우 사이즈를 변경할 때 마다 영상의 크기 및 자막창의 크기를 반응형으로 수정하였습니다.
2. 영상 설명 박스 및 자막 박스 CSS 를 추가하였습니다.
3. 한국어/영어 자막 선택, 자막창 켜기/끄기 옵션을 추가하였습니다.
### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.

### 화면캡쳐 (필요시)
<img width="1088" alt="image" src="https://github.com/Team-Office360/NeedleInHaystack-client/assets/139360841/f42c6258-7ddd-4c67-9b18-420b70238ea1">
