### PR TITLE
Feat: enable logged-in user to delete search history

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -3,8 +3,8 @@ import { Link, useNavigate } from "react-router-dom";
 import {
   BugAntIcon,
   UserCircleIcon,
-  ArrowUturnLeftIcon,
   ArrowRightStartOnRectangleIcon,
+  ChevronLeftIcon,
 } from "@heroicons/react/24/solid";
 
 import axios from "axios";
@@ -106,20 +106,17 @@ function Header() {
   }
 
   return (
-    <div className="flex gap-10 lg:gap-20 justify-between items-center sticky top-0 z-10 bg-white ">
-      <div className="flex mx-4 gap-4 items-center shrink">
+    <div className="flex justify-center sm:justify-between items-center w-screen shrink sticky top-0 gap-4 lg:gap-8 my-8 px-4 py-2 z-10 bg-white ">
+      <div className="flex items-center">
         {headerState === "DetailPage" && (
           <button
-            className="flex p-3 rounded-full hover:bg-sky-50"
+            className="flex rounded-full hover:bg-sky-50"
             type="button"
             onClick={() => {
               navigate(-1);
             }}
           >
-            <ArrowUturnLeftIcon
-              className="h-[25px] justify-center items-center"
-              alt="Back"
-            />
+            <ChevronLeftIcon className="w-6" alt="Back" />
           </button>
         )}
         {headerState !== "MainPage" && (
@@ -127,7 +124,7 @@ function Header() {
             <Link to="/">
               <div className="flex items-center justify-center text-center ">
                 <img
-                  className="w-6"
+                  className="w-6 mx-2"
                   src="/assets/LogoSample2.png"
                   alt="Logo"
                   onClick={handleLogoClick}
@@ -144,13 +141,13 @@ function Header() {
       </div>
       {!isLoggedIn ? (
         <div
-          className="hidden sm:flex py-4 my-4 mr-4 ml-auto p-2 items-center border rounded-full hover:bg-sky-50 cursor-pointer"
+          className="hidden sm:flex mr-4 ml-auto p-2 items-center border rounded-full hover:bg-sky-50 cursor-pointer"
           onClick={handleLogin}
           role="button"
           tabIndex={0}
         >
           <UserCircleIcon
-            className="h-[35px] items-center fill-blue-300"
+            className="w-6 items-center fill-blue-300"
             alt="signIn"
           />
           <p className="px-1">Sign in</p>

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -128,7 +128,8 @@ function Header() {
                   src="/assets/LogoSample2.png"
                   alt="Logo"
                   onClick={handleLogoClick}
-                  role="presentation"
+                  role="button"
+                  tabIndex={0}
                 />
                 <div className="p-2 hidden text-xl font-bold">
                   Needle In Haystack

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -5,14 +5,17 @@ import {
   UserCircleIcon,
   ArrowUturnLeftIcon,
   ArrowRightStartOnRectangleIcon,
-  ChevronLeftIcon,
 } from "@heroicons/react/24/solid";
 
 import axios from "axios";
 
 import { signInWithPopup, signOut } from "firebase/auth";
 import { auth, provider } from "../../config/firebase";
-import { useUserStore, useHeaderStateStore } from "../../store/store";
+import {
+  useUserStore,
+  useHeaderStateStore,
+  useUserInputStore,
+} from "../../store/store";
 
 import SearchInput from "../SearchInput";
 
@@ -20,6 +23,7 @@ function Header() {
   const navigate = useNavigate();
   const { user, setUser, isLoggedIn, setIsLoggedIn } = useUserStore();
   const { headerState } = useHeaderStateStore();
+  const { setUserInput } = useUserInputStore();
   const [isUserIconClicked, setUserIconClicked] = useState(false);
 
   useEffect(() => {
@@ -97,18 +101,25 @@ function Header() {
     }
   }
 
+  function handleLogoClick() {
+    setUserInput("");
+  }
+
   return (
-    <div className="flex justify-center sm:justify-between items-center w-screen shrink sticky top-0 gap-4 lg:gap-8 my-8 px-4 py-2 z-10 bg-white ">
-      <div className="flex items-center">
+    <div className="flex gap-10 lg:gap-20 justify-between items-center sticky top-0 z-10 bg-white ">
+      <div className="flex mx-4 gap-4 items-center shrink">
         {headerState === "DetailPage" && (
           <button
-            className="flex rounded-full hover:bg-sky-50"
+            className="flex p-3 rounded-full hover:bg-sky-50"
             type="button"
             onClick={() => {
               navigate(-1);
             }}
           >
-            <ChevronLeftIcon className="w-6" alt="Back" />
+            <ArrowUturnLeftIcon
+              className="h-[25px] justify-center items-center"
+              alt="Back"
+            />
           </button>
         )}
         {headerState !== "MainPage" && (
@@ -116,9 +127,11 @@ function Header() {
             <Link to="/">
               <div className="flex items-center justify-center text-center ">
                 <img
-                  className="w-6 mx-2"
+                  className="w-6"
                   src="/assets/LogoSample2.png"
                   alt="Logo"
+                  onClick={handleLogoClick}
+                  role="presentation"
                 />
                 <div className="p-2 hidden text-xl font-bold">
                   Needle In Haystack
@@ -131,13 +144,13 @@ function Header() {
       </div>
       {!isLoggedIn ? (
         <div
-          className="hidden sm:flex mr-4 ml-auto p-2 items-center border rounded-full hover:bg-sky-50 cursor-pointer"
+          className="hidden sm:flex py-4 my-4 mr-4 ml-auto p-2 items-center border rounded-full hover:bg-sky-50 cursor-pointer"
           onClick={handleLogin}
           role="button"
           tabIndex={0}
         >
           <UserCircleIcon
-            className="w-6 items-center fill-blue-300"
+            className="h-[35px] items-center fill-blue-300"
             alt="signIn"
           />
           <p className="px-1">Sign in</p>

--- a/src/components/SearchInput/index.jsx
+++ b/src/components/SearchInput/index.jsx
@@ -18,6 +18,7 @@ function SearchInput() {
   const [selectedItemIndex, setSelectedItemIndex] = useState(-1);
   const [showAutoCompletions, setShowAutoCompletions] = useState(false);
   const [showSearchHistory, setShowSearchHistory] = useState(false);
+  const [referenceIndex, setReferenceIndex] = useState(0);
 
   const navigate = useNavigate();
   const inputRef = useRef(null);
@@ -51,6 +52,7 @@ function SearchInput() {
         const { data } = response;
 
         setAutoCompletions(data.searchHistories);
+        setReferenceIndex(data.referenceIndex);
       } catch (error) {
         console.error(error);
       }
@@ -139,17 +141,21 @@ function SearchInput() {
     }
   }
 
-  function handleMouseHover(event) {
+  function handleMouseEnter(event) {
     const index = Number(event.target.getAttribute("index"));
 
     setSelectedItemIndex(index);
   }
 
-  function handleAutoCompletionClick(event) {
+  function handleMouseLeave() {
+    setSelectedItemIndex(-1);
+  }
+
+  function handleAutoCompletionClick() {
     const selectedKeyword = autoCompletions[selectedItemIndex];
     const keywords = selectedKeyword.replace(/\s+/g, " ").split(" ").join("+");
 
-    setUserInput(event.target.textContent);
+    setUserInput(selectedKeyword);
     setShowAutoCompletions(false);
 
     navigate(`/results?search_query=${keywords}`);
@@ -186,13 +192,44 @@ function SearchInput() {
     navigate(`/results?search_query=${keywords}`);
   }
 
+  function handleDeleteClick(event) {
+    event.stopPropagation();
+    const itemToDelete = autoCompletions[selectedItemIndex];
+    const index = autoCompletions.indexOf(itemToDelete);
+
+    setAutoCompletions((prev) => {
+      const newArray = [...prev];
+
+      newArray.splice(index, 1);
+
+      return newArray;
+    });
+
+    async function deleteAutoCompletions(itemToDelete) {
+      try {
+        await axios.delete(
+          `${import.meta.env.VITE_BASE_URL}/auto-completions`,
+          {
+            params: { itemToDelete },
+            withCredentials: true,
+          },
+        );
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    deleteAutoCompletions();
+    setSelectedItemIndex((prev) => prev + 1);
+  }
+
   return (
-    <div className="relative flex flex-col justify-center items-center gap-4 flex-grow max-w-[380px] sm:max-w-[600px]">
+    <div className="relative flex flex-col gap-4 flex-grow max-w-[600px] items-center justify-center">
       <div className="flex flex-grow w-full">
         <input
           type="search"
           placeholder="Search Needle"
-          className="rounded-l-full border border-secondary-border shadow-inner shadow-secondary bg-white py-2 px-4 text-xl w-full focus:border-green-300 outline-none"
+          className="rounded-l-full border border-secondary-border shadow-inner shadow-secondary py-2 px-4 text-xl w-full focus:border-blue-500 outline-none"
           value={userInput}
           onChange={handleUserInputChange}
           onKeyDown={handleKeyPress}
@@ -217,19 +254,26 @@ function SearchInput() {
           {autoCompletions.map((autoCompletion, index) => (
             <div
               key={autoCompletion}
-              className={`flex items-center w-full h-10 py-2 text-xl rounded-md ${Number(index) === selectedItemIndex ? "bg-secondary-hover" : ""}`}
-              onMouseEnter={handleMouseHover}
-              onMouseLeave={handleMouseHover}
+              className={`flex items-center w-full py-3 text-xl rounded-md ${Number(index) === selectedItemIndex ? "bg-secondary-hover" : ""} ${index < referenceIndex || userInput === "" ? "text-violet-600" : ""}`}
+              onMouseEnter={handleMouseEnter}
+              onMouseLeave={handleMouseLeave}
               onClick={handleOptionClick}
               index={index}
               role="presentation"
             >
-              {isLoggedIn ? (
+              {isLoggedIn && index < referenceIndex ? (
                 <ClockIcon className="h-6 mx-2" />
               ) : (
                 <MagnifyingGlassIcon className="h-6 mx-2" />
               )}
               {autoCompletion}
+              <span
+                className={`${(index < referenceIndex || userInput === "") && index === selectedItemIndex ? "block" : "hidden"} text-gray-500 ml-auto mr-4 hover:underline`}
+                onClick={handleDeleteClick}
+                role="presentation"
+              >
+                delete
+              </span>
             </div>
           ))}
         </button>

--- a/src/components/SearchInput/index.jsx
+++ b/src/components/SearchInput/index.jsx
@@ -270,7 +270,7 @@ function SearchInput() {
               )}
               {autoCompletion}
               <span
-                className={`${(index < referenceIndex || userInput === "") && index === selectedItemIndex ? "block" : "hidden"} text-gray-500 ml-auto mr-4 hover:underline`}
+                className={`${(index < referenceIndex || userInput === "") && index === selectedItemIndex ? "block" : "hidden"} ml-auto mr-4 text-gray-500 hover:underline`}
                 onClick={handleDeleteClick}
                 role="presentation"
               >

--- a/src/components/SearchInput/index.jsx
+++ b/src/components/SearchInput/index.jsx
@@ -18,7 +18,7 @@ function SearchInput() {
   const [selectedItemIndex, setSelectedItemIndex] = useState(-1);
   const [showAutoCompletions, setShowAutoCompletions] = useState(false);
   const [showSearchHistory, setShowSearchHistory] = useState(false);
-  const [referenceIndex, setReferenceIndex] = useState(0);
+  const [referenceIndex, setReferenceIndex] = useState(10);
 
   const navigate = useNavigate();
   const inputRef = useRef(null);
@@ -254,7 +254,9 @@ function SearchInput() {
           {autoCompletions.map((autoCompletion, index) => (
             <div
               key={autoCompletion}
-              className={`flex items-center w-full py-3 text-xl rounded-md ${Number(index) === selectedItemIndex ? "bg-secondary-hover" : ""} ${index < referenceIndex || userInput === "" ? "text-violet-600" : ""}`}
+              className={`flex items-center w-full py-3 text-xl rounded-md ${Number(index) === selectedItemIndex ? "bg-secondary-hover" : ""}
+              ${index < referenceIndex ? "text-violet-600" : "text-black"}
+              `}
               onMouseEnter={handleMouseEnter}
               onMouseLeave={handleMouseLeave}
               onClick={handleOptionClick}

--- a/src/components/SearchInput/index.jsx
+++ b/src/components/SearchInput/index.jsx
@@ -194,8 +194,8 @@ function SearchInput() {
 
   function handleDeleteClick(event) {
     event.stopPropagation();
-    const itemToDelete = autoCompletions[selectedItemIndex];
-    const index = autoCompletions.indexOf(itemToDelete);
+    const historyToDelete = autoCompletions[selectedItemIndex];
+    const index = autoCompletions.indexOf(historyToDelete);
 
     setAutoCompletions((prev) => {
       const newArray = [...prev];
@@ -205,12 +205,12 @@ function SearchInput() {
       return newArray;
     });
 
-    async function deleteAutoCompletions(itemToDelete) {
+    async function deleteAutoCompletions(historyToDelete) {
       try {
         await axios.delete(
           `${import.meta.env.VITE_BASE_URL}/auto-completions`,
           {
-            params: { itemToDelete },
+            params: { historyToDelete },
             withCredentials: true,
           },
         );
@@ -219,7 +219,7 @@ function SearchInput() {
       }
     }
 
-    deleteAutoCompletions();
+    deleteAutoCompletions(historyToDelete);
     setSelectedItemIndex((prev) => prev + 1);
   }
 


### PR DESCRIPTION
### [[FE/BE] 로그인 유저 자동 완성 삭제 기능](https://www.notion.so/seongjunhong/FE-BE-54fd83248f534c55a4132d1f302b4b48?pvs=4)

### 작업한 내용

1. 로그인한 유저가 인풋창을 클릭하면 아래 목록을 보여주도록 수정하였습니다.
a. 최근 검색어 (시계 아이콘, 보라색)
b. 다른 사용자가 가장 많이 검색한 검색어 (돋보기 아이콘, 검은색)
2. 자동 완성 목록을 최대 10개 까지만 보여 주도록 수정하였습니다.
3. 로그인한 유저가 본인의 검색 기록을 삭제하는 기능을 추가하였습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.

### 화면캡쳐
![image](https://github.com/Team-Office360/NeedleInHaystack-client/assets/139360841/71e9112b-2264-44e0-b4d0-52881cd27586)
![image](https://github.com/Team-Office360/NeedleInHaystack-client/assets/139360841/9f04684c-4007-4a8f-a55d-7f01b3b680b5)


