### PR TITLE
Refactor: change api to save videoId for autoCrawling

### DIFF
--- a/src/components/VideoDetailPage/index.jsx
+++ b/src/components/VideoDetailPage/index.jsx
@@ -6,20 +6,14 @@ import axios from "axios";
 import Header from "../Header";
 import Video from "../Video";
 import VideoScript from "../VideoScript";
-import { Loading, CustomLoading } from "../shared/Loading";
+import { CustomLoading } from "../shared/Loading";
 
-import {
-  useAutoCrawlingTimerStore,
-  useHeaderStateStore,
-  usePlayerDimensions,
-} from "../../store/store";
+import { useHeaderStateStore, usePlayerDimensions } from "../../store/store";
 import CONSTANT from "../../constants/constant";
 
 function VideoDetailPage() {
   const { video } = useLocation().state;
   const { setHeaderState } = useHeaderStateStore();
-  const { autoCrawlingTimer, setAutoCrawlingTimer } =
-    useAutoCrawlingTimerStore();
   const { playerDimensions } = usePlayerDimensions();
 
   const [currentVideoTime, setCurrentVideoTime] = useState(0);
@@ -45,24 +39,18 @@ function VideoDetailPage() {
   useEffect(() => {
     setHeaderState("DetailPage");
 
-    async function autoCrawling(videoId) {
-      setAutoCrawlingTimer(true);
-
+    async function saveVideoId(videoId) {
       const response = await axios.post(
-        `${import.meta.env.VITE_BASE_URL}/admin/autoCrawling`,
+        `${import.meta.env.VITE_BASE_URL}/admin/saveVideoId`,
         {
           videoId,
         },
       );
 
-      setAutoCrawlingTimer(false);
-
       return response.data;
     }
 
-    if (!autoCrawlingTimer) {
-      autoCrawling(video.youtubeVideoId);
-    }
+    saveVideoId(video.youtubeVideoId);
   }, []);
 
   function handleToggleClick() {

--- a/src/components/VideoList/index.jsx
+++ b/src/components/VideoList/index.jsx
@@ -7,6 +7,7 @@ import useFetchSingleVideo from "../../apis/useFetchSingleVideo";
 import CONSTANT from "../../constants/constant";
 
 import { useUserInputStore } from "../../store/store";
+import { LoadingSpin } from "../shared/Loading";
 
 function VideoList({ innerRef, youtubeVideoId }) {
   const navigate = useNavigate();
@@ -61,7 +62,7 @@ function VideoList({ innerRef, youtubeVideoId }) {
 
   return (
     <div ref={videoComponent}>
-      {!isFetching && (
+      {!isFetching ? (
         <Link to={`/watch?${video.youtubeVideoId}`} state={{ video }}>
           <div
             ref={innerRef}
@@ -133,6 +134,10 @@ function VideoList({ innerRef, youtubeVideoId }) {
             </div>
           </div>
         </Link>
+      ) : (
+        <div className="flex justify-center items-center w-[340px] h-[180px]">
+          <LoadingSpin />
+        </div>
       )}
     </div>
   );

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -30,16 +30,10 @@ const usePlayerDimensions = create((set) => ({
   setPlayerDimensions: (playerDimensions) => set({ playerDimensions }),
 }));
 
-const useAutoCrawlingTimerStore = create((set) => ({
-  autoCrawlingTimer: false,
-  setAutoCrawlingTimer: (autoCrawlingTimer) => set({ autoCrawlingTimer }),
-}));
-
 export {
   useUserInputStore,
   useCheckSpellStore,
   useUserStore,
   useHeaderStateStore,
   usePlayerDimensions,
-  useAutoCrawlingTimerStore,
 };


### PR DESCRIPTION
### [[FE/BE] 크롤링 자동화 ](https://www.notion.so/seongjunhong/FE-BE-4e65d36afc384da2b9ff2fd41a38470b?pvs=4)

### description

- 사용자가 동영상을 시청하러 videoDetail page로 들어가면 해당 비디오id를 DB에 저장합니다.
- 저장한 비디오id는 후에 크롤러가 연관 동영상들을 스크래핑하는데 사용합니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.